### PR TITLE
Refactor JsonRequestLoggerMiddleware for single responsibility and flexible configuration

### DIFF
--- a/asgi_request_logger/json_request_logger_middleware.py
+++ b/asgi_request_logger/json_request_logger_middleware.py
@@ -60,6 +60,7 @@ class JsonRequestLoggerMiddleware:
         
         if logger is None:
             raise ValueError("A logger must be provided")
+        self.logger = logger
 
     async def __call__(
         self,
@@ -127,7 +128,9 @@ class JsonRequestLoggerMiddleware:
             log_data["error"] = {}
             for src_key, dest_key in self.error_info_mapping.items():
                 log_data["error"][dest_key] = error_info.get(src_key)
-
+            if "state" in scope and isinstance(scope["state"], dict):
+                scope["state"][self.error_info_name] = None
+                
         log_data.update({
             "time_taken_ms": time_taken_ms,
             "status_code": response_status_code,

--- a/asgi_request_logger/logger.py
+++ b/asgi_request_logger/logger.py
@@ -1,0 +1,41 @@
+import logging
+import queue
+from logging.handlers import QueueHandler, QueueListener
+
+class QueueLoggerDict:
+    def __init__(self, logger: logging.Logger, listener: QueueListener):
+        self.logger = logger
+        self.listener = listener
+
+def get_queue_logger(
+    max_queue_size: int = 1000,
+    logger_name: str = "request-logger",
+    log_level: int = logging.INFO,    
+) -> QueueLoggerDict:
+    """get QueueHandler logger with its QueueListener<br/>
+    
+    you should trigger `listener.start()` for queue logger working properly
+    
+    Args:
+        max_queue_size (int, optional): max queue size to apply on queue handlers queue. Defaults to 1000.
+        logger_name (str, optional): logger name. Defaults to "request-logger".
+        log_level (int, optional): default logging level. Defaults to logging.INFO.
+    Returns:
+        class: QueueLoggerDict("logger": logger, "listener": listener)
+    """
+    log_queue = queue.Queue(maxsize=max_queue_size)
+    queue_handler = QueueHandler(log_queue)
+    
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(message)s")
+    stream_handler.setFormatter(formatter)
+    
+    listener = QueueListener(log_queue, stream_handler)
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(log_level)
+    logger.handlers.clear()
+    logger.addHandler(queue_handler)
+    logger.propagate = False
+    
+    return QueueLoggerDict(logger=logger, listener=listener)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asgi-request-logger"
-version = "0.2.0"
+version = "0.3.0"
 description = "A lightweight request logger middleware for ASGI applications"
 authors = ["timothy jeong <k.jts8257@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asgi-request-logger"
-version = "0.3.0"
+version = "0.3.1"
 description = "A lightweight request logger middleware for ASGI applications"
 authors = ["timothy jeong <k.jts8257@gmail.com>"]
 license = "MIT"

--- a/tests/test_json_request_logger_middleware.py
+++ b/tests/test_json_request_logger_middleware.py
@@ -1,6 +1,5 @@
 import json
 import logging
-
 import pytest
 from asgiref.typing import Scope, ASGIReceiveCallable, ASGISendCallable
 
@@ -15,93 +14,21 @@ class ListHandler(logging.Handler):
     def emit(self, record: logging.LogRecord) -> None:
         self.records.append(self.format(record))
 
-# A dummy ASGI app that returns a 200 response.
-async def dummy_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
-    # Send response start message with status 200.
+# A dummy ASGI app that simulates a 500 error.
+async def error_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
     await send({
         "type": "http.response.start",
-        "status": 200,
-        "headers": [(b"content-type", b"text/plain")],
+        "status": 500,
+        "headers": [(b"content-type", b"application/json")],
     })
-    # Send response body.
     await send({
         "type": "http.response.body",
-        "body": b"OK",
+        "body": b"Internal Server Error",
     })
-
-@pytest.mark.asyncio
-async def test_json_request_logger_success():
-    # Set up a custom logger with ListHandler to capture log output.
-    test_logger = logging.getLogger("test_logger_success")
-    test_logger.setLevel(logging.INFO)
-    list_handler = ListHandler()
-    formatter = logging.Formatter("%(message)s")
-    list_handler.setFormatter(formatter)
-    test_logger.handlers = [list_handler]
-    test_logger.propagate = False
-
-    # Wrap the dummy app with the JsonRequestLoggerMiddleware.
-    middleware = JsonRequestLoggerMiddleware(
-        app=dummy_app,
-        event_id_header="X-Event-ID",
-        client_ip_headers=["x-forwarded-for", "x-real-ip"],
-        logger=test_logger,
-    )
-    
-    # remove warning
-    list_handler.records.clear()
-
-    # Create a fake HTTP scope with headers.
-    scope: Scope = {
-        "type": "http",
-        "http_version": "1.1",
-        "method": "GET",
-        "path": "/test",
-        "headers": [
-            (b"x-forwarded-for", b"203.0.113.1"),
-            (b"user-agent", b"pytest"),
-            (b"x-event-id", b"test-event-id"),
-        ],
-        "client": ("127.0.0.1", 12345),
-        "state": {},  # No error info.
-    }
-
-    # Dummy receive function.
-    async def receive() -> dict:
-        return {"type": "http.request"}
-
-    # Dummy send function that collects sent events.
-    sent_messages = []
-    async def send(message: dict) -> None:
-        sent_messages.append(message)
-
-    # Invoke the middleware.
-    await middleware(scope, receive, send)
-
-    # Ensure a log record was captured.
-    assert len(list_handler.records) > 0
-
-    # Parse the logged JSON.
-    log_record = json.loads(list_handler.records[0])
-    assert log_record["method"] == "GET"
-    assert log_record["path"] == "/test"
-    # event_id should come from the header.
-    assert log_record["event_id"] == "test-event-id"
-    # client_ip should be extracted from x-forwarded-for header.
-    assert log_record["client_ip"] == "203.0.113.1"
-    # status_code is 200.
-    assert log_record["status_code"] == 200
-    # Log type and level.
-    assert log_record["log_type"] == "access"
-    assert log_record["level"] == "INFO"
-    # time_taken_ms should be an integer.
-    assert isinstance(log_record["time_taken_ms"], int)
-    # error should be None.
-    assert log_record["error"] is None
 
 @pytest.mark.asyncio
 async def test_json_request_logger_error():
-    # Set up a custom logger to capture log output.
+    # Set up a custom logger with ListHandler to capture log output.
     test_logger = logging.getLogger("test_logger_error")
     test_logger.setLevel(logging.INFO)
     list_handler = ListHandler()
@@ -111,24 +38,12 @@ async def test_json_request_logger_error():
     test_logger.propagate = False
 
     # Create a dummy ASGI app that simulates a 500 error.
-    async def error_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
-        await send({
-            "type": "http.response.start",
-            "status": 500,
-            "headers": [(b"content-type", b"application/json")],
-        })
-        await send({
-            "type": "http.response.body",
-            "body": b"Internal Server Error",
-        })
-
-    # Wrap the error app with the JsonRequestLoggerMiddleware.
     middleware = JsonRequestLoggerMiddleware(
         app=error_app,
         logger=test_logger,
     )
     
-    # remove warning
+    # Remove any pre-existing log records (e.g. warnings).
     list_handler.records.clear()
 
     # Create a fake HTTP scope with error information in state.
@@ -175,3 +90,6 @@ async def test_json_request_logger_error():
     assert error_info["error_code"] == "TEST_ERROR"
     assert error_info["error_message"] == "An error occurred"
     assert error_info["stack_trace"] == ["trace1", "trace2"]
+
+    # Verify that error_info in the scope has been cleared after logging.
+    assert scope.get("state", {}).get("error_info") is None


### PR DESCRIPTION
- Require logger injection instead of internal logger creation, giving users full control over logging configuration.
- Introduce the log_info_mapping parameter to allow static mapping of ASGI scope (or header) fields to log fields.
- Clear error_info from the scope after logging to prevent unnecessary propagation and reduce memory overhead.
- Simplify configuration and improve resource management by decoupling logger and listener handling.
